### PR TITLE
Fix:- tableName retrieval from query parameters

### DIFF
--- a/functions/zoho_analytics_datastore_sync_routes_handler/index.js
+++ b/functions/zoho_analytics_datastore_sync_routes_handler/index.js
@@ -156,7 +156,7 @@ app.post('/export-datastore', async (req, res) => {
 
 app.post('/import-analytics', async (req, res) => {
   const catalystApp = catalyst.initialize(req)
-  const tableName = req.body.tableName
+  const tableName = req.query.tableName
   const cache = catalystApp.cache()
   const segment = await cache.getSegmentDetails(AppConstants.CatalystComponents.Segment.Analytics)
   try {


### PR DESCRIPTION
The `tableName` parameter was incorrectly retrieved from `req.body`, causing issues when the client sent it as a query parameter.

Fix:-

Changed the code to use `req.query.tableName` instead of `req.body.tableName`.
